### PR TITLE
Added authentication for backstore and implemented sign out link for front and backstore

### DIFF
--- a/app/public/backstore/added-user.php
+++ b/app/public/backstore/added-user.php
@@ -1,5 +1,9 @@
 <?php require_once("../../resources/config.php");
 
+if (!isset($_COOKIE["admin"])) {
+  header("Location: ../index.php");
+}
+
 if(isset($_POST['submit'])) {
     $xml = new DOMDocument('1.0', "UTF-8");
 

--- a/app/public/backstore/delete_product.php
+++ b/app/public/backstore/delete_product.php
@@ -1,4 +1,8 @@
-<?php require_once("../../resources/config.php"); 
+<?php require_once("../../resources/config.php");
+
+if (!isset($_COOKIE["admin"])) {
+  header("Location: ../index.php");
+}
 
 if(isset($_GET['id']) && isset($_GET['category'])) {
     $product_aisle = htmlspecialchars($_GET["category"]);

--- a/app/public/backstore/delete_user.php
+++ b/app/public/backstore/delete_user.php
@@ -1,5 +1,9 @@
 <?php require_once("../../resources/config.php");
 
+if (!isset($_COOKIE["admin"])) {
+  header("Location: ../index.php");
+}
+
 if(isset($_GET['id'])) {
     $user_id =  htmlspecialchars($_GET["id"]);
 

--- a/app/public/backstore/edited-user.php
+++ b/app/public/backstore/edited-user.php
@@ -1,5 +1,9 @@
 <?php require_once("../../resources/config.php");
 
+if (!isset($_COOKIE["admin"])) {
+  header("Location: ../index.php");
+}
+
 if(isset($_POST['submit'])) {
     $xml = new DOMDocument('1.0', "UTF-8");
 

--- a/app/public/sign-out.php
+++ b/app/public/sign-out.php
@@ -1,0 +1,9 @@
+<?php
+  if (isset($_COOKIE["admin"])) {
+    setcookie("admin", "", 1, "/MooMoo-Grocery-2/app/public");
+  } else if (isset($_COOKIE["user"])) {
+    setcookie("user", "", 1, "/MooMoo-Grocery-2/app/public");
+  }
+
+  header("Location: index.php");
+?>

--- a/app/resources/functions.php
+++ b/app/resources/functions.php
@@ -299,8 +299,8 @@ function deleteUserXml($user_id) {
 
 //returns next unused user ID
 function getNextUserID() {
-  $xmla = simplexml_load_file(XML_DB . DS . "users.xml") or die("Error: Cannot create object");
-  $nextID = $xmla->next[0];
+  $xml = simplexml_load_file(XML_DB . DS . "users.xml") or die("Error: Cannot create object");
+  $nextID = $xml->next[0];
 
   return $nextID;
 }

--- a/app/resources/templates/back/header.php
+++ b/app/resources/templates/back/header.php
@@ -17,7 +17,14 @@
 </head>
 
 <body>
+
+  <?php
+  if (!isset($_COOKIE["admin"])) {
+    header("Location: ../index.php");
+  }
+  ?>
+
   <header class="backstore-header">
     <a href="../index.php"><img class="backstore-header-logo" src="../images/moomoologo.png" alt="MooMooGrocery logo"></a>
-    <a class="sign-out-button" href="../index.php">Sign Out</a>
+    <a class="sign-out-button" href="../sign-out.php">Sign Out</a>
   </header>

--- a/app/resources/templates/front/aisle-header.php
+++ b/app/resources/templates/front/aisle-header.php
@@ -52,10 +52,24 @@
                         </div>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="../Login.php">Sign In</a>
+                      <?php
+                        if (isset($_COOKIE["admin"]) || isset($_COOKIE["user"])) {
+                          echo '<a class="nav-link" href="../sign-out.php">Sign Out</a>';
+                        } else {
+                          echo '<a class="nav-link" href="../Login.php">Sign In</a>';
+                        }
+                      ?>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" id="register-link" href="../SignUp.php">Register</a>
+                      <?php
+                        if (isset($_COOKIE["user"])) {
+                          echo '<a class="nav-link" id="register-link" href="../SignUp.php" style="display: none">Register</a>';
+                        } else if (isset($_COOKIE["admin"])) {
+                          echo '<a class="nav-link" id="backstore-link" href="../backstore/order-list.php" >Backstore</a>';
+                        } else {
+                          echo '<a class="nav-link" id="register-link" href="../SignUp.php">Register</a>';
+                        }
+                      ?>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="../cart.php"><span

--- a/app/resources/templates/front/header.php
+++ b/app/resources/templates/front/header.php
@@ -52,10 +52,24 @@
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="Login.php">Sign In</a>
+            <?php
+              if (isset($_COOKIE["admin"]) || isset($_COOKIE["user"])) {
+                echo '<a class="nav-link" href="sign-out.php">Sign Out</a>';
+              } else {
+                echo '<a class="nav-link" href="Login.php">Sign In</a>';
+              }
+            ?>
           </li>
           <li class="nav-item">
-            <a class="nav-link" id="register-link" href="SignUp.php">Register</a>
+            <?php
+              if (isset($_COOKIE["user"])) {
+                echo '<a class="nav-link" id="register-link" href="SignUp.php" style="display: none">Register</a>';
+              } else if (isset($_COOKIE["admin"])) {
+                echo '<a class="nav-link" id="backstore-link" href="backstore/order-list.php" >Backstore</a>';
+              } else {
+                echo '<a class="nav-link" id="register-link" href="SignUp.php">Register</a>';
+              }
+            ?>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="cart.php"><span class="material-icons md-24">shopping_cart</span></a>

--- a/app/resources/templates/front/product-navbar.php
+++ b/app/resources/templates/front/product-navbar.php
@@ -37,7 +37,7 @@
               if (isset($_COOKIE["user"])) {
                 echo '<a class="nav-link text-primary" id="register-link" href="../SignUp.php" style="display: none">Register</a>';
               } else if (isset($_COOKIE["admin"])) {
-                echo '<a class="nav-link text-primary" id="backstore-link" href="../backstore/order-list.php" >Backstore</a>';
+                echo '<a class="nav-link" id="backstore-link" href="../backstore/order-list.php" >Backstore</a>';
               } else {
                 echo '<a class="nav-link text-primary" id="register-link" href="../SignUp.php">Register</a>';
               }

--- a/app/resources/templates/front/product-navbar.php
+++ b/app/resources/templates/front/product-navbar.php
@@ -23,11 +23,25 @@
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="../Login.php">Sign In</a>
+            <?php
+              if (isset($_COOKIE["admin"]) || isset($_COOKIE["user"])) {
+                echo '<a class="nav-link" href="../sign-out.php">Sign Out</a>';
+              } else {
+                echo '<a class="nav-link" href="../Login.php">Sign In</a>';
+              }
+            ?>
           </li>
           <!-- Different color for register link -->
           <li class="nav-item">
-            <a class="nav-link text-primary" href="../SignUp.php">Register</a>
+            <?php
+              if (isset($_COOKIE["user"])) {
+                echo '<a class="nav-link text-primary" id="register-link" href="../SignUp.php" style="display: none">Register</a>';
+              } else if (isset($_COOKIE["admin"])) {
+                echo '<a class="nav-link text-primary" id="backstore-link" href="../backstore/order-list.php" >Backstore</a>';
+              } else {
+                echo '<a class="nav-link text-primary" id="register-link" href="../SignUp.php">Register</a>';
+              }
+            ?>
           </li>
           <!-- Icon for shopping cart -->
           <li class="nav-item">


### PR DESCRIPTION
Links in header of frontstore pages now change depending on what type of user is logged in (if any user is logged in, Sign In link becomes Sign Out link, if "user" is logged in, Register link is hidden, if "admin" is logged in Register link becomes Backstore link).
After pressing Sign Out from any page (front or back), the cookie is deleted and user is redirected to Index page.
Only "admin" may access the backstore pages.